### PR TITLE
Consideration of time latency of measurement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ include_directories(
   ${Eigen3_INCLUDE_DIRS}
 )
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")
+
 
 ## pluginlib_tutorials library
 add_library(kf_pos_vel_acc_pluginlib src/kf_pos_vel_acc_plugin.cpp)

--- a/include/kalman_filter/kf_base_plugin.h
+++ b/include/kalman_filter/kf_base_plugin.h
@@ -229,26 +229,21 @@ namespace kf_plugin
       measurement_noise_covariance_ = measure_sigma_m * measure_sigma_m;
     }
 
-    inline int getId() { return id_;}
+    inline const int getId() const { return id_;}
     inline void setId(int id) { id_ = id;}
 
-    VectorXd getEstimateState()
+    const VectorXd& getEstimateState()
     {
+      /* can not add const suffix for this function, because of the lock_guard */
       boost::lock_guard<boost::mutex> lock(kf_mutex_);
       return estimate_state_;
     }
 
-    void getEstimateState(vector<double>& estiamte_state )
-    {
-      boost::lock_guard<boost::mutex> lock(kf_mutex_);
-      estimate_state_;
-    }
+    inline const MatrixXd getEstimateCovariance() const { return estimate_covariance_;}
 
-    inline MatrixXd getEstimateCovariance(){ return estimate_covariance_;}
-
-    inline int getStateDim(){return state_dim_;}
-    inline int getInputDim(){return input_dim_;}
-    inline int getMeasureDim(){return measure_dim_;}
+    inline const int getStateDim() const {return state_dim_;}
+    inline const int getInputDim() const {return input_dim_;}
+    inline const int getMeasureDim() const {return measure_dim_;}
 
     inline void setStateTransitionModel(MatrixXd state_transition_model){state_transition_model_ = state_transition_model;}
     inline void setControlInputModel(MatrixXd control_input_model){control_input_model_ = control_input_model;}

--- a/include/kalman_filter/kf_pos_vel_acc_plugin.h
+++ b/include/kalman_filter/kf_pos_vel_acc_plugin.h
@@ -67,8 +67,8 @@ namespace kf_plugin
     void initialize(ros::NodeHandle nh, string suffix, int id);
 
     /* be sure that the first parma should be timestamp */
-    void updatePredictModel(const vector<double>& params = vector<double>(0));
-    void updateCorrectModel(const vector<double>& params = vector<double>(0));
+    void getPredictModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& state_transition_model, MatrixXd& control_input_model) const;
+    void getCorrectModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& observation_model) const;
 
   private:
     //dynamic reconfigure
@@ -97,10 +97,10 @@ namespace kf_plugin
     void initialize(ros::NodeHandle nh, string suffix, int id);
 
     /* be sure that the first parma should be timestamp */
-    void updatePredictModel(const vector<double>& params = vector<double>(0));
-    void updateCorrectModel(const vector<double>& params = vector<double>(0));
+    void getPredictModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& state_transition_model, MatrixXd& control_input_model) const;
+    void getCorrectModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& observation_model) const;
 
-      private:
+  private:
     //dynamic reconfigure
     dynamic_reconfigure::Server<kalman_filter::KalmanFilterPosVelAccBiasConfig>* server_;
     dynamic_reconfigure::Server<kalman_filter::KalmanFilterPosVelAccBiasConfig>::CallbackType dynamic_reconf_func_;

--- a/src/kf_pos_vel_acc_plugin.cpp
+++ b/src/kf_pos_vel_acc_plugin.cpp
@@ -50,7 +50,7 @@ namespace kf_plugin
   }
 
   /* be sure that the first parma should be timestamp */
-  void KalmanFilterPosVelAcc::updatePredictModel(const vector<double>& params)
+    void KalmanFilterPosVelAcc::getPredictModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& state_transition_model, MatrixXd& control_input_model) const
   {
     assert(params.size() == 1);
 
@@ -58,37 +58,37 @@ namespace kf_plugin
 
     assert(dt >= 0);
 
-    Matrix2d state_transition_model;
-    state_transition_model << 1, dt, 0, 1;
-    setStateTransitionModel(state_transition_model);
+    Matrix2d state_transition_model_temp;
+    state_transition_model_temp << 1, dt, 0, 1;
+    state_transition_model = state_transition_model_temp;
 
-    Matrix<double, 2, 1> control_input_model;
-    control_input_model << (dt * dt)/2, dt;
-    setControlInputModel(control_input_model);
+    Matrix<double, 2, 1> control_input_model_temp;
+    control_input_model_temp << (dt * dt)/2, dt;
+    control_input_model = control_input_model_temp;
   }
 
   /* be sure that the first parma is timestamp */
-  void KalmanFilterPosVelAcc::updateCorrectModel(const vector<double>& params)
+    void KalmanFilterPosVelAcc::getCorrectModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& observation_model) const
   {
     /* params: correct mode */
     assert(params.size() == 1);
     assert((int)params[0] <= VEL);
 
-    Matrix<double, 1, 2> observation_model;
+    Matrix<double, 1, 2> observation_model_temp;
     switch((int)params[0])
       {
       case POS:
         {
-          observation_model << 1, 0;
+          observation_model_temp << 1, 0;
           break;
         }
       case VEL:
         {
-          observation_model << 0, 1;
+          observation_model_temp << 0, 1;
           break;
         }
       }
-    setObservationModel(observation_model);
+    observation_model = observation_model_temp;
   }
 
   void KalmanFilterPosVelAcc::cfgCallback(kalman_filter::KalmanFilterPosVelAccConfig &config, uint32_t level)
@@ -127,42 +127,42 @@ namespace kf_plugin
     server_->setCallback(dynamic_reconf_func_);
   }
 
-  void KalmanFilterPosVelAccBias::updatePredictModel(const vector<double>& params)
+  void KalmanFilterPosVelAccBias::getPredictModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& state_transition_model, MatrixXd& control_input_model) const
   {
     assert(params.size() == 1);
 
     float dt = params[0];
 
-    Matrix3d state_transition_model;
-    state_transition_model << 1, dt, -dt*dt/2, 0, 1, -dt, 0, 0, 1;
-    setStateTransitionModel(state_transition_model);
+    Matrix3d state_transition_model_temp;
+    state_transition_model_temp << 1, dt, -dt*dt/2, 0, 1, -dt, 0, 0, 1;
+    state_transition_model = state_transition_model_temp;
 
-    Matrix<double, 3, 2> control_input_model;
-    control_input_model << (dt * dt)/2, 0, dt, 0, 0, 1;
-    setControlInputModel(control_input_model);
+    Matrix<double, 3, 2> control_input_model_temp;
+    control_input_model_temp << (dt * dt)/2, 0, dt, 0, 0, 1;
+    control_input_model = control_input_model_temp;
   }
 
-  void KalmanFilterPosVelAccBias::updateCorrectModel(const vector<double>& params)
+  void KalmanFilterPosVelAccBias::getCorrectModel(const vector<double>& params, const VectorXd& estimate_state, MatrixXd& observation_model) const
   {
     /* params: correct mode */
     assert(params.size() == 1);
     assert((int)params[0] <= VEL);
 
-    Matrix<double, 1, 3> observation_model;
+    Matrix<double, 1, 3> observation_model_temp;
     switch((int)params[0])
       {
       case POS:
         {
-          observation_model << 1, 0, 0;
+          observation_model_temp << 1, 0, 0;
           break;
         }
       case VEL:
         {
-          observation_model << 0, 1, 0;
+          observation_model_temp << 0, 1, 0;
           break;
         }
       }
-    setObservationModel(observation_model);
+    observation_model = observation_model_temp;
   }
 
 


### PR DESCRIPTION
Improve the kalman filter methods, with the function to check the difference of timestamp between input and measurement based on following paper:

[S. Weiss, M. W. Achtelik, M. Chli and R. Siegwart, "Versatile distributed pose estimation and sensor self-calibration for an autonomous MAV," 2012 IEEE International Conference on Robotics and Automation, Saint Paul, MN, 2012, pp. 31-38](https://ieeexplore.ieee.org/document/6225002/)

In fact, the previous implementation already contain the function to synchronize the timestamp between input and measurement. However, the implementation algorithm is accompanied high computation consumption, since the covariance is also re-propagated every time. Such problem is solved based on the paper mentioned above.
