### PR TITLE
Fix Bug: forbid the reference variables in the function contraining mutex

### DIFF
--- a/include/kalman_filter/kf_base_plugin.h
+++ b/include/kalman_filter/kf_base_plugin.h
@@ -111,9 +111,9 @@ namespace kf_plugin
       init_state_ = VectorXd::Zero(state_dim_);
     }
 
-    virtual bool prediction(const VectorXd& input, /* the vector of input */
+    virtual bool prediction(const VectorXd input, /* the vector of input */
                             const double timestamp, /* the timestamp of prediction state(which will be the timestamp for whole system) */
-                            const vector<double>& params = vector<double>(0) /* the vector of param for predict model */)
+                            const vector<double> params = vector<double>(0) /* the vector of param for predict model */)
     {
       std::lock_guard<std::recursive_mutex> lock(kf_mutex_);
 
@@ -172,10 +172,10 @@ namespace kf_plugin
       return true;
     }
 
-    virtual bool correction(const VectorXd& measurement, /* the vector of measurement */
-                            const VectorXd& noise_sigma, /* the vector of measure sigma */
+    virtual bool correction(const VectorXd measurement, /* the vector of measurement */
+                            const VectorXd noise_sigma, /* the vector of measure sigma */
                             const double timestamp = -1, /* timestamp of the measure state */
-                            const vector<double>& params = vector<double>(0), /* the vector of param for correct model, the first param should be timestamp */
+                            const vector<double> params = vector<double>(0), /* the vector of param for correct model, the first param should be timestamp */
                             const double outlier_thresh = 0 /*  check the outlier */)
     {
       /* lock the whole process, since several sensor may acess in the same time */
@@ -239,7 +239,7 @@ namespace kf_plugin
       init_state_(no) = state_value;
     }
 
-    inline void setInitState(const VectorXd& init_state)
+    inline void setInitState(const VectorXd init_state)
     {
       std::lock_guard<std::recursive_mutex> lock(kf_mutex_);
       assert(init_state_.size() == init_state.size());
@@ -264,7 +264,7 @@ namespace kf_plugin
       measurement_noise_covariance = measure_sigma_m * measure_sigma_m;
     }
 
-    const VectorXd& getEstimateState()
+    const VectorXd getEstimateState()
     {
       /* can not add const suffix for this function, because of the lock_guard */
       std::lock_guard<std::recursive_mutex> lock(kf_mutex_);
@@ -274,7 +274,7 @@ namespace kf_plugin
         return init_state_; //no predction
     }
 
-    inline const MatrixXd& getEstimateCovariance()
+    inline const MatrixXd getEstimateCovariance()
     {
       /* TODO: this not correct, if we consider the delay (latency) in time_sync mode */
       std::lock_guard<std::recursive_mutex> lock(kf_mutex_);
@@ -572,7 +572,7 @@ namespace kf_plugin
         }
     }
 
-    const bool measurementOutlierCheck(const VectorXd& residual, const MatrixXd& covariance, const double& outlier_thresh)
+    const bool measurementOutlierCheck(const VectorXd& residual, const MatrixXd& covariance, const double& outlier_thresh) const
     {
       double mahalonobis_dist_square = residual.transpose() * covariance.inverse() * residual;
 

--- a/include/kalman_filter/kf_pos_vel_acc_plugin.h
+++ b/include/kalman_filter/kf_pos_vel_acc_plugin.h
@@ -62,8 +62,8 @@ namespace kf_plugin
 
     void initialize(string name, int id);
 
-    bool prediction(const VectorXd& input, const double timestamp, const vector<double>& params = vector<double>(0));
-
+    /* speical overwrite */
+    bool prediction(const VectorXd input, const double timestamp, const vector<double> params = vector<double>(0));
     void setPredictionNoiseCovariance(const VectorXd& input_sigma_v);
 
     /* be sure that the first parma should be timestamp */

--- a/src/kf_pos_vel_acc_plugin.cpp
+++ b/src/kf_pos_vel_acc_plugin.cpp
@@ -84,9 +84,9 @@ namespace kf_plugin
     KalmanFilter::setPredictionNoiseCovariance(input_sigma_v_temp);
   }
 
-  bool KalmanFilterPosVelAcc::prediction(const VectorXd& input,
+  bool KalmanFilterPosVelAcc::prediction(const VectorXd input,
                                          const double timestamp,
-                                         const vector<double>& params)
+                                         const vector<double> params)
   {
     if(input.size() == 1 && estimate_acc_bias_) // special process for bias estimation
       {


### PR DESCRIPTION
We can not use the variables called by reference in the function which contains mutex.